### PR TITLE
refactor midi interfaces: unify halo use

### DIFF
--- a/NTMI_AI_sc_setup/3_interfaces/optionals/ec4.scd
+++ b/NTMI_AI_sc_setup/3_interfaces/optionals/ec4.scd
@@ -36,21 +36,6 @@ row 4 buttons: 4x randomize sound settings
 var m;
 m = NTMI.makeMKtl(\ec4, "*ec4_basic", NTMI.currInfo);
 
-m.addHalo(\zoom, 1);
-m.addSpec(\zoom, [0, 4, \amp]);
-NTMI.put(m.name, m.getHalo);
-
-m.getHalo.putAll((
-	influxMode: \setRel,
-	setAbs: { |dict|
-		"*** % only has setRel.\n".postf(m);
-		dict.influxMode = \setRel;
-	},
-	setRel: { "*** % is always setRel.\n".postf(m) },
-	zoom: 1,
-	butDown: Set[],
-	butsUsedForMode: false
-));
 
 // name them first:
 m.addNamed(\FXstep, m.elAt(0, \kn, 0));

--- a/NTMI_AI_sc_setup/3_interfaces/optionals/en16.scd
+++ b/NTMI_AI_sc_setup/3_interfaces/optionals/en16.scd
@@ -36,21 +36,6 @@ var m;
 
 m = NTMI.makeMKtl('en16', "intech-grid", NTMI.currInfo);
 
-m.addHalo(\zoom, 1);
-m.addSpec(\zoom, [0, 4, \amp]);
-NTMI.put(m.name, m.getHalo);
-
-m.getHalo.putAll((
-	influxMode: \setRel,
-	setAbs: { |dict|
-		"*** % only has setRel.\n".postf(m);
-		dict.influxMode = \setRel;
-	},
-	setRel: { "*** % is always setRel.\n".postf(m) },
-	zoom: 1,
-	butDown: Set[],
-	butsUsedForMode: false
-));
 
 // name them first:
 m.addNamed(\FXstep, m.elAt(\enc, 0));

--- a/NTMI_AI_sc_setup/3_interfaces/optionals/mu8.scd
+++ b/NTMI_AI_sc_setup/3_interfaces/optionals/mu8.scd
@@ -44,22 +44,8 @@ MKtlDesc("music_thing_8mu").elAt(\acc).elements.do { |eldesc|
 	eldesc.style.put(\height, 2);
 };
 
-// prepare for NTMI influx:
-m.addHalo(\zoom, 1);
-m.addHalo(\influxMode, \setRel);
 m.addHalo(\butDown, Set[]);
 m.addHalo(\butsUsedForMode, false);
-
-NTMI.put(m.name, m.getHalo);
-
-m.getHalo.setRel = {
-	m.getHalo.influxMode = 'setRel';
-	"*** % influxMode: \n".postf(m.name, m.getHalo.influxMode);
-};
-m.getHalo.setAbs = {
-	"*** % has no setAbs, so: \n".postf(m.name);
-	m.getHalo.setRel;
-};
 
 // rightmost slider is main vol:
 MKtl('mu8').elAt(\sl, 7).action = { |sl|
@@ -96,8 +82,6 @@ MKtl('mu8').elAt(\bt).action = { |bt|
 
 MKtl('mu8').addNamed(\modSl, MKtl('mu8').elAt(\sl, (0..6)));
 
-m.getHalo.zoomSpec = [0, 4, \amp].asSpec;
-m.getHalo.lastPreTime = 0;
 (
 MKtl('mu8').elAt(\modSl).action = { |sl|
 	case { m.getHalo.butDown.isEmpty } {
@@ -126,8 +110,9 @@ MKtl('mu8').elAt(\modSl).action = { |sl|
 			NTMI.incZoom(sl.deviceValue - sl.prevDeviceValue / 64);
 
 		} { sl.indexInGroup == 4 } {
-			var uniNewVal = m.getHalo.zoomSpec.unmap(m.getHalo.zoom) + (step / 64);
-			m.getHalo.zoom = m.getHalo.zoomSpec.map(uniNewVal);
+			var spec = \xZoom.asSpec;
+			var uniNewVal = spec.unmap(m.getHalo.zoom) + (step / 64);
+			m.getHalo.zoom = spec.map(uniNewVal);
 			"%.zoom: %\n".postf(m.name, m.getHalo.zoom);
 		} { sl.indexInGroup < 4 } {
 			var ndef = NTMI.ndefs[sl.indexInGroup];

--- a/NTMI_AI_sc_setup/3_interfaces/optionals/nanoKtl.scd
+++ b/NTMI_AI_sc_setup/3_interfaces/optionals/nanoKtl.scd
@@ -30,31 +30,6 @@ MKtl(\nanoKtl).elAt(\bt)
 var m = NTMI.makeMKtl(\nanoKtl, "*trol2", NTMI.currInfo);
 
 
-// support multiple identical interfaces:
-
-// give m a local zoom value:
-m.addSpec(\zoom, [0, 4, \amp]);
-// create halo by adding zoom value,
-// and sync it as NTMI space for m:
-m.addHalo(\zoom, 1);
-
-// then allow direct access of halo via NTMI:
-NTMI.q.put(m.name, m.getHalo);
-
-// flag whether to use influx in relative or absolute mode:
-// (there could be more modes, e.g. softAbs ...)
-m.getHalo.influxMode = \setRel;
-
-// set functions to switch between the two supported modes:
-m.getHalo.setRel = {
-	m.getHalo.influxMode = \setRel;
-	"*** % influxMode is now: %\n.".postf(m.name, \setRel);
-};
-m.getHalo.setAbs = {
-	m.getHalo.influxMode = \setAbs;
-	"*** % influxMode is now: %\n.".postf(m.name, \setAbs);
-};
-
 // make all named elements first
 m.addNamed(\main, m.elAt(\sl, 7));
 m.addNamed(\inflSet, m.elAt(\sl, (0..6)));

--- a/NTMI_AI_sc_setup/3_interfaces/optionals/nanoKtl1.scd
+++ b/NTMI_AI_sc_setup/3_interfaces/optionals/nanoKtl1.scd
@@ -49,32 +49,6 @@ m.addNamed(\rand_pre, m.elAt(\tr, \loop));
 m.addNamed(\prev_pre, m.elAt(\tr, \stop));
 m.addNamed(\next_pre, m.elAt(\tr, \rec));
 
-// *** add local settings and functions to nanoKtl ***
-// local zoom value:
-m.addSpec(\zoom, [0, 4, \amp]);
-m.addHalo(\zoom, 1);
-
-// allow direct access of halo via NTMI:
-NTMI.q.put(m.name, m.getHalo);
-// and access like this
-m.getHalo.zoom.postln;
-
-// flag whether to use influx in relative or absolute mode:
-// (there could be more modes, e.g. softAbs ...)
-m.getHalo.influxMode = \setRel;
-
-// set functions for the two supported modes:
-m.getHalo.setRel = {
-	m.getHalo.influxMode = \setRel;
-	"nanoKtl1 influxMode is now: %\n.".postf(\setRel);
-};
-m.getHalo.setAbs = {
-	m.getHalo.influxMode = \setAbs;
-	"nanoKtl1 influxMode is now: %\n.".postf(\setAbs);
-};
-// read and set:
-m.getHalo.influxMode;
-m.getHalo.setRel;
 
 m.elAt(\inflSet).do(_.value = 0.5);
 

--- a/NTMI_AI_sc_setup/3_interfaces/optionals/uc4.scd
+++ b/NTMI_AI_sc_setup/3_interfaces/optionals/uc4.scd
@@ -91,37 +91,6 @@ m.elAt('pgSl1', \sl).value = 0.5;
 m.elAt('main').value = 0.5;
 
 
-
-// *** add local settings and functions to uc4 ***
-// local zoom value:
-m.addSpec(\zoom, [0, 4, \amp]);
-m.addHalo(\zoom, 1);
-
-
-// allow direct access of halo via NTMI:
-NTMI.put(m.name, m.getHalo);
-// and access like this
-m.getHalo.zoom.postln;
-
-// flag whether to use influx in relative or absolute mode:
-// (there could be more modes, e.g. softAbs ...)
-m.getHalo.influxMode = \setRel;
-
-// set functions for the two supported modes:
-m.getHalo.setRel = {
-	m.getHalo.influxMode = \setRel;
-	"uc4 influxMode is now: %\n.".postf(\setRel);
-};
-
-m.getHalo.setAbs = {
-	m.getHalo.influxMode = \setAbs;
-	"uc4 influxMode is now: %\n.".postf(\setAbs);
-};
-// read and set:
-m.getHalo.influxMode;
-m.getHalo.setRel;
-
-
 /// lower 4 knobs change slots volume
 m.elAt(\vols).do { |el, i|
 	el.action = { |el|

--- a/NTMI_AI_sc_setup/3_interfaces/optionals/xtm.scd
+++ b/NTMI_AI_sc_setup/3_interfaces/optionals/xtm.scd
@@ -37,28 +37,6 @@ var m;
 
 m = NTMI.makeMKtl(\xtm, "*x-touch-mini*", NTMI.currInfo);
 
-// give m a local zoom value:
-m.addSpec(\zoom, [0, 4, \amp]);
-// create halo by adding zoom value,
-// and sync it as NTMI space for m:
-m.addHalo(\zoom, 1);
-
-// then allow direct access of halo via NTMI:
-NTMI.q.put(m.name, m.getHalo);
-
-// flag whether to use influx in relative or absolute mode:
-// (there could be more modes, e.g. softAbs ...)
-m.getHalo.influxMode = \setRel;
-
-// set functions to switch between the two supported modes:
-m.getHalo.setRel = {
-	m.getHalo.influxMode = \setRel;
-	"% influxMode is now: setRel\n.".postf(m.name);
-};
-m.getHalo.setAbs = {
-	m.getHalo.influxMode = \setAbs;
-	"% influxMode is now: setAbs.\n".postf(m.name);
-};
 
 // main volume
 m.addNamed(\main, m.elAt(\A, \sl));


### PR DESCRIPTION
This PR unifies near-duplication between interfaces:
In the interface files, the halo of an MKtl becomes a dict in NTMI, where influxMode etc live: 
```
MKtl(\uc4).getHalo == NTMI.uc4;
-> ( 'zoom': 1, 'sliderOffset': 1, 'mktl': MKtl('uc4') )

// the default methods for switching influxMode are in a separate dict:
NTMI.baseMKtlHalo
```
This halo is made in the NTMI.makeMKtl method now.

*** To Do:
unify across ALL interfaces, incl. HID and OSC. 
